### PR TITLE
allow using external build

### DIFF
--- a/main.go
+++ b/main.go
@@ -132,7 +132,10 @@ func downloadIfRequired(downloadPattern string, version string, name string, exc
         downloadedFile := path.Join(cacheTmpDir, "downloaded.tar.gz")
         err = sh.Run("wget", url, "-O", downloadedFile)
         if err != nil {
-            return "", err
+            err = sh.Run("curl", "--fail", "-LSso", downloadedFile, url)
+            if err != nil {
+                return "", err
+            }
         }
 
         err = os.MkdirAll(cacheDir, 0755)

--- a/main.go
+++ b/main.go
@@ -12,8 +12,30 @@ import (
     "strings"
 )
 
+func GetDownloadUrl(path string, version string) (string, error) {
+    if strings.HasPrefix(path, "http") {
+        return VerifyUrl(path)
+    } else {
+        return GetApacheDownloadUrl(fmt.Sprintf(path, version, version))
+    }
+}
+
 func GetApacheDownloadUrl(path string) (string, error) {
-    url := fmt.Sprintf("https://www-eu.apache.org/dist/" + path)
+    urls := [...]string {
+        "https://www-eu.apache.org/dist/" + path,
+        "https://archive.apache.org/dist/" + path,
+    }
+
+    for _, url := range urls {
+        if _, err := VerifyUrl(url); err == nil {
+            return url, nil
+        }
+    }
+
+    return "", errors.New("Can't find download url for " + path)
+}
+
+func VerifyUrl(url string) (string, error) {
     resp, err := http.Head(url)
     if err != nil {
         return "", err
@@ -21,16 +43,7 @@ func GetApacheDownloadUrl(path string) (string, error) {
     if resp.StatusCode == 200 {
         return url, nil
     }
-    url = fmt.Sprintf("https://archive.apache.org/dist/" + path)
-    resp, err = http.Head(url)
-    if err != nil {
-        return "", err
-    }
-    if resp.StatusCode == 200 {
-        return url, nil
-    }
-    return "", errors.New("Can't find download url for " + path)
-
+    return "", errors.New("Package not found at " + url)
 }
 
 type FlokkrDescriptor struct {
@@ -110,7 +123,7 @@ func BuildContainer(desc FlokkrDescriptor, version string, tags []string) error 
 }
 
 func downloadIfRequired(downloadPattern string, version string, name string, excludes []string) (string, error) {
-    url, err := GetApacheDownloadUrl(fmt.Sprintf(downloadPattern, version, version))
+    url, err := GetDownloadUrl(downloadPattern, version)
     if err != nil {
         return "", err
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Allow using external build (specified by URL) instead of building URL for specific version.

## How was this patch tested?

Set `urlpath: http://xenia.sote.hu/ftp/mirrors/www.apache.org/hadoop/ozone/ozone-1.0.0/hadoop-ozone-1.0.0.tar.gz` in https://github.com/flokkr/docker-ozone/blob/102ed692f4ddf41d246d5f79274d9994c6302c0f/flokkr.yaml#L3.

```
$ mage -v build
Running target: Build
exec: wget http://xenia.sote.hu/ftp/mirrors/www.apache.org/hadoop/ozone/ozone-1.0.0/hadoop-ozone-1.0.0.tar.gz -O .cache/work/downloaded.tar.gz
exec: curl --fail -LSso .cache/work/downloaded.tar.gz http://xenia.sote.hu/ftp/mirrors/www.apache.org/hadoop/ozone/ozone-1.0.0/hadoop-ozone-1.0.0.tar.gz
exec: tar xzf .cache/work/downloaded.tar.gz --directory .cache/ozone/1.0.0 --strip-components=1
exec: docker build -t flokkr/ozone:build --build-arg ARTIFACTDIR=.cache/ozone/1.0.0 --build-arg BASE=37 .
Sending build context to Docker daemon  651.1MB
Step 1/8 : ARG BASE=latest
Step 2/8 : FROM flokkr/base:${BASE}
 ---> e3c42f9dd12a
Step 3/8 : ARG ARTIFACTDIR
 ---> Using cache
 ---> 16f98511ac67
Step 4/8 : RUN alternatives --set java java-latest-openjdk.x86_64
 ---> Using cache
 ---> e3da5f834981
Step 5/8 : ADD ${ARTIFACTDIR} /opt/ozone
 ---> a792121b6596
Step 6/8 : ENV CONF_DIR /opt/ozone/etc/hadoop
 ---> Running in f8ccd43e955d
Removing intermediate container f8ccd43e955d
 ---> 560e190da338
Step 7/8 : ENV PATH $PATH:/opt/ozone/bin
 ---> Running in 51b00ddf0d53
Removing intermediate container 51b00ddf0d53
 ---> f6cb8ee31402
Step 8/8 : WORKDIR /opt/ozone
 ---> Running in 202ce466eeac
Removing intermediate container 202ce466eeac
 ---> 528787b73171
Successfully built 528787b73171
Successfully tagged flokkr/ozone:build
exec: docker tag flokkr/ozone:build flokkr/ozone:latest
exec: docker tag flokkr/ozone:build flokkr/ozone:1.0.0
exec: docker tag flokkr/ozone:build flokkr/ozone:1.0
exec: docker tag flokkr/ozone:build flokkr/ozone:1

$ docker run -it --rm flokkr/ozone:1.0.0 ozone version
Flokkr launcher script 1.1-18-g58a3efc

===== Plugin is activated ENVTOCONF =====
======================================
*** Launching "ozone version"
                  //////////////
               ////////////////////
            ////////     ////////////////
           //////      ////////////////
          /////      ////////////////  /
         /////            ////////   ///
         ////           ////////    /////
        /////         ////////////////
        /////       ////////////////   //
         ////     ///////////////   /////
         /////  ///////////////     ////
          /////       //////      /////
           //////   //////       /////
             ///////////     ////////
               //////  ////////////
               ///   //////////
              /    1.0.0(Denali)

Source code repository https://github.com/apache/hadoop-ozone.git -r 28d372ca903b4741131bace09e0339e9161257bb
Compiled by sammi on 2020-08-25T13:05Z
Compiled with protoc 2.5.0
From source with checksum 49ea4ac8358b9bfbdcda09565e1fcd8

Using HDDS 1.0.0
Source code repository https://github.com/apache/hadoop-ozone.git -r 28d372ca903b4741131bace09e0339e9161257bb
Compiled by sammi on 2020-08-25T13:04Z
Compiled with protoc 2.5.0
From source with checksum 29d5395b7722c8e946ac646b3b23f05a
Process exited with exit code 0
